### PR TITLE
Add Next+Prev links to markdown files

### DIFF
--- a/00/README.md
+++ b/00/README.md
@@ -17,3 +17,5 @@ const user = {
 
 output(user);
 ```
+
+[Next](../01/README.md)

--- a/01/README.md
+++ b/01/README.md
@@ -16,3 +16,5 @@ Create a state machine that toggles the `#box` between the `inactive` and `activ
 
 - Use object syntax instead of a `switch` statement instead.
 - Create a self-contained interpreter that uses a closure to keep track of the current state machine value. Get creative!
+
+[Prev](../00/README.md) • [Next](../02/README.md)

--- a/02/README.md
+++ b/02/README.md
@@ -19,3 +19,5 @@ npm install xstate
 ## Extra Credit
 
 - Get a feel for the shorthand and the object transition syntax. Which do you prefer?
+
+[Prev](../01/README.md) • [Next](../03/README.md)

--- a/03/README.md
+++ b/03/README.md
@@ -18,3 +18,5 @@ Interpret state machines by using an interpreter. The machine should toggle betw
 
 - Send the raw event from the event handler to the service instead. Notice how it fits the event object shape!
 - Practice stopping the service when you no longer need it with `service.stop()` (e.g., after 10 seconds or so).
+
+[Prev](../02/README.md) • [Next](../04/README.md)

--- a/04/README.md
+++ b/04/README.md
@@ -26,3 +26,5 @@ createMachine(
   }
 );
 ```
+
+[Prev](../03/README.md) • [Next](../05/README.md)

--- a/05/README.md
+++ b/05/README.md
@@ -17,3 +17,5 @@ Use `context` to update the extended state of the drag/drop state machine. You w
 ## Extra Credit
 
 - Listen for `keyup` events on the body. When `Escape` is pressed, we should cancel dragging and reset the box to its original position. Where would this transition go?
+
+[Prev](../04/README.md) • [Next](../06/README.md)

--- a/06/README.md
+++ b/06/README.md
@@ -13,3 +13,5 @@ Use a guarded transition and `context` to prevent the `#box` from being dragged 
 ## Extra Credit
 
 - Listen for `keyup` events on the body. When `Escape` is pressed, we should cancel dragging and reset the box to its original position. Where would this transition go?
+
+[Prev](../05/README.md) • [Next](../07/README.md)

--- a/07/README.md
+++ b/07/README.md
@@ -15,3 +15,5 @@ We don't want the `#box` to be draggable unless we are authorized (i.e., there i
 ## Extra Credit
 
 - If we're not authorized, give us a chance to sign in. The sign in button is available on the page. What should this transition look like, and where should it transition to?
+
+[Prev](../06/README.md) • [Next](../08/README.md)

--- a/08/README.md
+++ b/08/README.md
@@ -12,3 +12,5 @@ Ensure that you can't drag the box for more than 2 seconds.
 ## Extra Credit
 
 - How would you make the timeout configurable from the `context` instead?
+
+[Prev](../07/README.md) • [Next](../09/README.md)

--- a/09/README.md
+++ b/09/README.md
@@ -12,3 +12,5 @@ When the <kbd>shift</kbd> key is pressed while dragging, we want the `#box` to o
 ## Extra Credit
 
 - Can you do something similar for the Y-axis? Naturally, we can't lock on the X-axis and Y-axis at the same time.
+
+[Prev](../08/README.md) • [Next](../10/README.md)

--- a/10/README.md
+++ b/10/README.md
@@ -16,3 +16,5 @@ Use a history state to "remember" what the most recent mode (child state) of the
 
 - Set the `target` of the history state to set the default target when there is no history. Without this, the machine will just go to the initial state of the parent state, which works for most use-cases.
 - What if there were two types of dark modes? Try using deep history to remember the deepest state.
+
+[Prev](../09/README.md) • [Next](../11/README.md)

--- a/11/README.md
+++ b/11/README.md
@@ -15,3 +15,5 @@ Currently, when our statechart is in the `visible` state, we can only control it
 ## Extra Credit
 
 - Try and see if a history state can remember where the screen was. This requires _deep_ history, not shallow history.
+
+[Prev](../10/README.md) • [Next](../12/README.md)

--- a/12/README.md
+++ b/12/README.md
@@ -14,3 +14,5 @@ Instead of a fire-and-forget action, we want to **invoke** an actor that will se
 - Add cancellation - if the user manually cancels the promise, we should get out of the `pending` state and back to the `idle` state. The promise will be cancelled automatically!
 - Likewise, let's set a timeout if the promise takes longer than expected. This should go to the `rejected` state.
 - Try invoking other things, like a machine, observable, or a callback.
+
+[Prev](../11/README.md) • [Next](https://twitter.com/swyx/status/1233187898943516673)


### PR DESCRIPTION
Very boring/basic style, but makes it easier to click through the rendered markdown on github :)